### PR TITLE
Add display fields to EndorsementCredential

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -77,6 +77,8 @@ Package SharedCredentialDataModels DataModel
         Property @context URI 1..*                                  "The value of the `@context` property MUST be an ordered set where the first item is a URI with the value 'https://www.w3.org/2018/credentials/v1', and the second item is a URI with the value 'https://purl.imsglobal.org/spec/ob/v3p0/context/ob_v3p0.jsonld'."
         Property type IRI 1..*                                      "The value of the type property MUST be an unordered set. One of the items MUST be the URI 'VerifiableCredential', and one of the items MUST be the URI 'EndorsementCredential'."
         Property id URI 1                                           "Unambiguous reference to the credential."
+        Property name String 1                                      "The name of the credential for display purposes in wallets. For example, in a list of credentials and in detail views."
+        Property description String 0..1                            "The short description of the credential for display purposes in wallets."
         Property credentialSubject EndorsementSubject 1             "The individual, entity, organization, assertion, or achievement that is endorsed and the endorsement comment."
 
     Class EndorsementSubject Unordered false [CredentialSubject]    "A collection of information about the subject of the endorsement."


### PR DESCRIPTION
Add `name` and `description` fields to EndorsementCredential to match AchievementCredential and ClrCredential. These are optional fields that can make summary displays (such as in wallets) easier.

I forgot to add them to EndorsementCredential.