### PR TITLE
Update integrity.md

### DIFF
--- a/ob_v3p0/integrity.md
+++ b/ob_v3p0/integrity.md
@@ -136,7 +136,7 @@ Verifiers that receive a OpenBadgeCredential in Compact JWS format MUST perform 
 
 ### Linked Data Proof Format {#lds-proof}
 
-This standard supports the Linked Data Proof format using the [[[VC-DI-EDDSA]]] suite.
+This standard supports the Linked Data Proof format. In order to opt for this format you MUST use the [[[VC-DI-EDDSA]]] suite.
 
 <div class="note">
   Whenever possible, you should use a library or service to create and verify a Linked Data Proof. For example, Digital Bazaar, Inc. has a GitHub project that implements the [[[VC-DI-EDDSA]]] eddsa-2022 suite at <a href="https://github.com/digitalbazaar/eddsa-2022-cryptosuite">https://github.com/digitalbazaar/eddsa-2022-cryptosuite</a>.


### PR DESCRIPTION
If issuer want to use LD-Signature. It has to use an specific cryptosuite. The spec is not clear that user MUST use that suite. So I propose this change:
Adding MUST, to sepecify conformant condition if LD-Signature is going to be used.