### PR TITLE
550 misuse of language in examples and i18n documentation

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -16,7 +16,7 @@ Package SharedCredentialDataModels DataModel
         Property fieldOfStudy String 0..1                           "Category, subject, area of study, discipline, or general branch of knowledge. Examples include Business, Education, Psychology, and Technology."
         Property humanCode String 0..1                              "The code, generally human readable, associated with an achievement."
         Property image Image 0..1                                   "An image representing the achievement."
-        Property @language LanguageCode 0..1                        "The language of the achievement."
+        Property inLanguage LanguageCode 0..1                       "The language of the achievement." "i:https://schema.org/inLanguage"
         Property name String 1                                      "The name of the achievement."
         Property otherIdentifier IdentifierEntry 0..*               "A list of identifiers for the described entity."
         Property related Related 0..*                               "The related property identifies another Achievement that should be considered the same for most purposes. It is primarily intended to identify alternate language editions or previous versions of Achievements."
@@ -137,7 +137,7 @@ Package SharedCredentialDataModels DataModel
     Class Related Unordered false []                                "Identifies a related achievement."
         Property id URI 1                                           "The related achievement."
         Property type IRI 1..* array-compacted                      "The value of the type property MUST be an unordered set. One of the items MUST be the IRI 'Related'."
-        Property @language LanguageCode 0..1                        "The language of the related achievement."
+        Property inLanguage LanguageCode 0..1                       "The language of the related achievement." "i:https://schema.org/inLanguage"
         Property version String 0..1                                "The version of the related achievement."
         Mixin Extensions
 

--- a/ob_v3p0/context-3.0.3.json
+++ b/ob_v3p0/context-3.0.3.json
@@ -61,6 +61,9 @@
         },
         "version": {
           "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#version"
+        },
+        "inLanguage": {
+          "@id": "https://schema.org/inLanguage"
         }
       }
     },
@@ -331,6 +334,9 @@
         "type": "@type",
         "version": {
           "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#version"
+        },
+        "inLanguage": {
+          "@id": "https://schema.org/inLanguage"
         }
       }
     },
@@ -416,6 +422,9 @@
     "image": {
       "@id": "https://purl.imsglobal.org/spec/vc/ob/vocab.html#image",
       "@type": "@id"
+    },
+    "inLanguage": {
+      "@id": "https://schema.org/inLanguage"
     },
     "name": {
       "@id": "https://schema.org/name"

--- a/ob_v3p0/impl/migrating.md
+++ b/ob_v3p0/impl/migrating.md
@@ -75,7 +75,7 @@ document, the full IRI `https://w3id.org/openbadges#BadgeClass` is used here).
 {
     "@context": "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
     "type": ["Achievement", "https://w3id.org/openbadges#BadgeClass"],
-    "@language": "en",
+    "inLanguage": "en",
     "id": "https://example.com/achievements/c3c1ea5b-9d6b-416d-ab7f-76da1df3e8d6"
     ...
     "related": [
@@ -90,7 +90,7 @@ document, the full IRI `https://w3id.org/openbadges#BadgeClass` is used here).
         {
             "type": ["Related"],
             "id": "https://example.com/achievements/c3c1ea5b-9d6b-416d-ab7f-76da1df3e8d6/es",
-            "@language": "es"
+            "inLanguage": "es"
         }
     ]
 }


### PR DESCRIPTION
Proposal to solve issue #550 using the action number 2:

> Add a new property inLanguage to the context, such as with the https://schema.org/inLanguage IRI and update relevant > classes, schema, and examples in implementation guide to use that property. This completely solves the problem with very > little "splash damage". But it doesn't take advantage of any JSON-LD special features for string labeling.


Rendered versions of the documents can be found at:
- Spec: https://github.com/1EdTech/openbadges-specification/blob/550-misuse-of-language-in-examples-and-i18n-documentation/docs/ob_v3p0.html
- Implementation Guide: https://github.com/1EdTech/openbadges-specification/blob/550-misuse-of-language-in-examples-and-i18n-documentation/docs/ob_v3p0_impl.html
I suggest to download the files and view them locally in a browser.