### PR TITLE
Add Result.status Provisional

### DIFF
--- a/ob_v3p0/common_credentials.lines
+++ b/ob_v3p0/common_credentials.lines
@@ -298,6 +298,7 @@ Package SharedCredentialDataModels DataModel
         Property Failed Term 1                                      "The learner has unsuccessfully completed the achievement."
         Property InProgress Term 1                                  "The learner has started progress in the activity described by the achievement."
         Property OnHold Term 1                                      "The learner has completed the activity described by the achievement, but successful completion has not been awarded, typically for administrative reasons."
+        Property Provisional Term 1                                 "The learner has completed the activity described by the achievement, but the completed result has not yet been confirmed."
         Property Withdrew Term 1                                    "The learner withdrew from the activity described by the achievement before completion."
 
 Package SharedProofDataModels DataModel                             "Data models shared by all proof formats."


### PR DESCRIPTION
The gap between "OnHold" with its somewhat negative connotation and "Completed" is big enough to squeeze in another possibility, "Provisional". This carries the expectation of an eventual completed result, but perhaps has not passed all administrative checks that will complete the status.

See existing terms: https://www.imsglobal.org/spec/ob/v3p0#org.1edtech.ob.v3p0.resultstatustype.class

I have some use cases for this for self-claimed badges that are not yet fully confirmed by their issuer, but may be useful to circulate in any case. Consumers SHOULD view this as an incomplete status, but they MAY consider it satisfactory.