### PR TITLE
Hotfix/typo in impl guide

### DIFF
--- a/ob_v3p0/impl/getting-started.md
+++ b/ob_v3p0/impl/getting-started.md
@@ -349,8 +349,8 @@ to submit a downloaded signed credential like the above for conformance checks.
 ### API quickstart
 
 The API of Open Badges 3.0 and Comprehensive Learner Record 2.0 is divided into
-four groups, wether the OB / CLR tool is a consumer or a provider of the API and
-wether the operations it consumes / provides are read operations or write
+four groups, whether the OB / CLR tool is a consumer or a provider of the API and
+whether the operations it consumes / provides are read operations or write
 operations.
 
 <div class="note">

--- a/ob_v3p0/impl/ob_impl_v3p0.html
+++ b/ob_v3p0/impl/ob_impl_v3p0.html
@@ -37,9 +37,9 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'impl', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '1.1',
+                docVersion: '1.2',
                 specStatus: 'Final Release',
-                specDate: 'Feb 12th, 2025',
+                specDate: 'Apr 7th, 2025',
                 contributors: _contributors,
                 localBiblio: _localBiblio,
                 iprs: _iprs,
@@ -258,11 +258,22 @@
                         <td>Version 3.0 IMS Candidate Final</td>
                         <td>Final Release</td>
                         <td>1.1</td>
-                        <td>Februart 12, 2025</td>
+                        <td>February 12, 2025</td>
                         <td>
                             <ul>
                             <li>Reorganization.</li>
                             <li>Clarified some paragraphs.</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Version 3.0 IMS Candidate Final</td>
+                        <td>Final Release</td>
+                        <td>1.2</td>
+                        <td>April 7, 2025</td>
+                        <td>
+                            <ul>
+                            <li>Fixed some typos.</li>
                             </ul>
                         </td>
                     </tr>


### PR DESCRIPTION
This pull request includes updates to documentation and version information for the Open Badges 3.0 and Comprehensive Learner Record 2.0 specifications. The most important changes include correcting typos, updating version details, and adding a new entry to the revision history.

Documentation updates:

* Corrected typos in the `ob_v3p0/impl/getting-started.md` file to change "wether" to "whether."

Version updates:

* Updated `docVersion` from '1.1' to '1.2' and `specDate` from 'Feb 12th, 2025' to 'Apr 7th, 2025' in the `ob_v3p0/impl/ob_impl_v3p0.html` file.
* Fixed a typo in the date "Februart 12, 2025" to "February 12, 2025" and added a new entry for version 1.2 with the date "April 7, 2025" in the revision history section of the `ob_v3p0/impl/ob_impl_v3p0.html` file.