### PR TITLE
Update document version from 1.2 to 2 in ob_impl_v3p0.html

### DIFF
--- a/ob_v3p0/impl/ob_impl_v3p0.html
+++ b/ob_v3p0/impl/ob_impl_v3p0.html
@@ -37,7 +37,7 @@
                 specNature: 'informative', // spec nature is "normative" or "informative"
                 specType: 'impl', // spec type is "main", "cert", "impl", "errata" or other agreed upon string
                 specVersion: '3.0',
-                docVersion: '1.2',
+                docVersion: '2',
                 specStatus: 'Final Release',
                 specDate: 'Apr 7th, 2025',
                 contributors: _contributors,
@@ -269,7 +269,7 @@
                     <tr>
                         <td>Version 3.0 IMS Candidate Final</td>
                         <td>Final Release</td>
-                        <td>1.2</td>
+                        <td>2</td>
                         <td>April 7, 2025</td>
                         <td>
                             <ul>


### PR DESCRIPTION
This pull request includes a couple of changes to the `ob_v3p0/impl/ob_impl_v3p0.html` file to update the document version.

Document version updates:

* [`ob_v3p0/impl/ob_impl_v3p0.html`](diffhunk://#diff-a1e11c8e7c9fce6e23299deb9450efd0f07449a2673da5bd83e3a7535990d72bL40-R40): Updated `docVersion` from '1.2' to '2' in the specification details section.
* [`ob_v3p0/impl/ob_impl_v3p0.html`](diffhunk://#diff-a1e11c8e7c9fce6e23299deb9450efd0f07449a2673da5bd83e3a7535990d72bL272-R272): Updated the document version from '1.2' to '2' in the revision history table.